### PR TITLE
Remove extra ':' at the end of the path

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,11 @@ EXTRA_TAURUS_PATHS="{0}"
 
 for path in $EXTRA_TAURUS_PATHS; do
     if ! echo $TAURUSQTDESIGNERPATH | grep -q $path; then
-        TAURUSQTDESIGNERPATH=$path:$TAURUSQTDESIGNERPATH
+        if [ -z ${{TAURUSQTDESIGNERPATH}} ]; then
+           TAURUSQTDESIGNERPATH=$path
+        else
+           TAURUSQTDESIGNERPATH=$TAURUSQTDESIGNERPATH:$path
+        fi
     fi
 done
 


### PR DESCRIPTION
Hej,


At MaxIV, the current folder path is added to the taurus widget path. This means that all the python file in the current folder are imported (and executed) when a command like `taurusform xxx` is executed.

This "feature/issue" is related to the script (from this project) deployed in /etc/profile.d/maxwidget.sh. The idea here is to append the maxwidget directory path to the taurus path. The variable `TAURUSQTDESIGNERPATH` is set like:
```
/tmp/lib/python2.7/site-packages/maxwidgets/input:/tmp/lib/python2.7/site-packages/maxwidgets/panel:/tmp/lib/python2.7/site-packages/maxwidgets/extra_guiqwt:/tmp/lib/python2.7/site-packages/maxwidgets/display:
```

The main issue is that the script adds at the end of the variable an extra `':'`. Taurus strictly splits each extra widget path on this character and import all the python files in each path ( [source](https://github.com/taurus-org/taurus/blob/bce54549a9f12458bcb1624d3d877789ae8b8489/lib/taurus/qt/qtgui/util/tauruswidgetfactory.py#L147) ). The issue is that the output of the split command is:
```
['/tmp/lib/python2.7/site-packages/maxwidgets/input',
 '/tmp/lib/python2.7/site-packages/maxwidgets/panel',
 '/tmp/lib/python2.7/site-packages/maxwidgets/extra_guiqwt',
 '/tmp/lib/python2.7/site-packages/maxwidgets/display',
 '']
```
The last line is due to this extra `':'` and means 'current path'.


My PR try to fix this issue.